### PR TITLE
Agon: Fix cmdline parser, improve string printing, tidying

### DIFF
--- a/rtl/agon.asm
+++ b/rtl/agon.asm
@@ -26,7 +26,6 @@ sysvar_vkeydown:    EQU 18h ; 1: Virtual key state from FabGL (0=up, 1=down)
 ;
 
 mos_call:
-;    push    ix     ;Doesn't need preserving at this stage
     ld      a,l     ;mos API routine to call
     push    de      ;address of register struct
     pop     ix
@@ -40,7 +39,6 @@ mos_call:
     ;ld hl,(IX+4) ->  LD HL,(IX+d) 0/1 5/6 DD, 27, dd
     db      0ddh, 027h, 04
 
-
     rst     08h ;MOS API call
     ;ld (IX+0),bc -> LD (IX+d),BC 0/1 5/6 DD, 0F, dd
     db      0ddh, 00Fh, 00h
@@ -50,7 +48,6 @@ mos_call:
     db      0ddh, 02Fh, 04h
     ld      l,a ;Return A into HL.
     ld      h,0
-;    pop     ix
     ret
 
 mos_call_oscli:
@@ -158,7 +155,6 @@ __getargvchar:
     add     hl,de   ;* 3
 
     ld      de,argv_ptrs
-;    add     hl,de
     push    hl
     pop     ix
     add     ix,de
@@ -181,7 +177,7 @@ __getargvchar:
 ;
 ; In:  A (ASCII code)
 ; Out:   -
-; Uses:   C,E,IY
+; Uses:   -
 ;
 __putc:
                 rst     10h
@@ -873,7 +869,6 @@ al_point_1:
 ; turn off logical scaling as soon as possible as we don't want this for pascal.
 al_setcoords:
               ld hl,__scaling_off_str
-              call  __puts
-              ret
+              jp    __puts
 __scaling_off_str: db 8,23,0,0c0h,0,23,16,1,254   ;VDU 23, 1, n: Cursor control
                                                   ;VDU 23, 16, setting, mask: Define cursor movement behaviour

--- a/rtl/agon.pas
+++ b/rtl/agon.pas
@@ -234,13 +234,11 @@ function ParamChar(Param: Byte; Bytenum: Byte): Char; register;        external 
  *)
 function ParamStr(I: Byte): String;
 var
-  CmdLine: String[128];
   Tmp: String[255];
   Tmpchar: Char;
-  C, D: Boolean;
   J: Byte;
 begin
-  C := True;
+  Tmp[0] := #255; //preset the length to maximum
 
   if I <= ParamCount then
     begin

--- a/rtl/agonhead.asm
+++ b/rtl/agonhead.asm
@@ -142,11 +142,7 @@ __init:
 ;
 ;
 __done:
-			mksis
 			ld		hl,(__exitcode)
-
-
-
 
 			mklil
 			POP		IX			; Restore the registers

--- a/rtl/system.asm
+++ b/rtl/system.asm
@@ -1729,6 +1729,16 @@ __conout:       equ     __putc
 ; Exit:   -
 ; Uses:   AF,BC
 ;
+        ifdef   SYS_AGON
+__puts:         ld      bc,0
+                ld      a,(hl)
+                or      a
+                ret     z
+                inc     hl
+                ld      c,a
+                rst     18h
+                ret
+        else
 __puts:         ld      b,(hl)
                 inc     b
                 jr      __putschk
@@ -1741,6 +1751,7 @@ __putsloop:     ld      a,(hl)
 __putschk:      inc     hl
                 djnz    __putsloop
                 ret
+        endif
 
 __lineptr:      ds      2
 


### PR DESCRIPTION
Agon: Fix command line parser bug (tmp string length not initialized), improve string printing (use native call), and tidying some source code by removing some unused code and variables.